### PR TITLE
Bugfix/summary stats

### DIFF
--- a/Report.txt
+++ b/Report.txt
@@ -3,7 +3,7 @@ but discarding the fragment part. So, for example, http://www.ics.uci.edu#aaa an
 Even if you implement additional methods for textual similarity detection, please keep considering the above definition of 
 unique pages for the purposes of counting the unique pages in this assignment.
 
-There are 28621 unique pages
+There are 28560 unique pages
 
 2. What is the longest page in terms of the number of words? (HTML markup doesn’t count as words)
 
@@ -15,6 +15,7 @@ Top 50 longest pages:
         http://www.ics.uci.edu/~wjohnson/BIDA/Ch8/posterioriterates.txt - 79762
         http://www.ics.uci.edu/~jacobson/cs122b/Project/04-FabFlixsTestData.txt - 48210
         https://www.stat.uci.edu/covid19/index.html - 29058
+        https://www.stat.uci.edu/covid19 - 29058
         https://www.stat.uci.edu/covid19/norcal-counties.html - 26895
         https://www.stat.uci.edu/covid19/la-norcal.html - 26884
         https://www.stat.uci.edu/covid19/oc-norcal.html - 26815
@@ -22,11 +23,12 @@ Top 50 longest pages:
         http://www.ics.uci.edu/~eppstein/junkyard/all.html - 22666
         https://sli.ics.uci.edu/AIStats/Postings - 22170
         http://www.ics.uci.edu/~eppstein/pubs/geom-all.html - 21786
+        http://dynamo.ics.uci.edu/files/zImage_paapi - 21499
         http://www.ics.uci.edu/~dsm/dyn/release/files/zImage_paapi - 21499
         https://cml.ics.uci.edu/category/aiml - 20169
         http://www.ics.uci.edu/~eppstein/bibs/eppstein.html - 19786
         http://www.ics.uci.edu/~eppstein/pubs/graph-all.html - 18887
-        http://graphics.ics.uci.edu/publication.html - 18465
+        https://graphics.ics.uci.edu/publication.html - 18465
         http://www.ics.uci.edu/~kay/courses/i42/wildride/data/1000customers.txt - 17798
         https://cml.ics.uci.edu/category/aiml/page/3 - 17389
         https://cml.ics.uci.edu/category/aiml/page/2 - 16699
@@ -50,72 +52,70 @@ Top 50 longest pages:
         https://duttgroup.ics.uci.edu/projects/self-aware-adaptive-computing/mars - 10548
         http://sli.ics.uci.edu/PmWiki/ReleaseNotes - 10473
         http://www.ics.uci.edu/%7Ewscacchi/Papers/VISTA/VISTA.html - 10454
-        http://www.ics.uci.edu/~dechter/talks/cambridge-pub.pps - 10396
         http://www.ics.uci.edu/~jacobson/ics10A/LabManual/08-Assignment5.html - 9662
         https://grape.ics.uci.edu/wiki/public/attachment/wiki/cs122b-2017-winter-project5/query_load.txt - 9456
-        https://grape.ics.uci.edu/wiki/public/attachment/wiki/cs122b-2018-spring-project5/query_load.txt - 9456
+        https://grape.ics.uci.edu/wiki/public/attachment/wiki/cs122b-2019-winter-project5/query_load.txt - 9456
         https://grape.ics.uci.edu/wiki/public/attachment/wiki/cs122b-2018-winter-project5/query_load.txt - 9456
         https://icde2023.ics.uci.edu/papers-research-track - 8674
         http://www.ics.uci.edu/~eppstein/pubs/Epp-IJCAI-85.lsp - 8413
         http://www.ics.uci.edu/~wjohnson/BIDA/Ch8/logoddstrauma.txt - 8104
         https://cml.ics.uci.edu/category/aiml/page/4 - 8039
-        http://www.ics.uci.edu/~dechter/publications.html - 7941
 
 3. What are the 50 most common words in the entire set of pages crawled under these domains? 
 (Ignore English stop words, which can be found, for example, hereLinks to an external site.) 
 Submit the list of common words ordered by frequency.
 
 The 50 most common words are:
-        research - 90715
-        ics - 68368
-        student - 54461
-        science - 49014
-        computer - 44676
-        learning - 41813
-        graduate - 41552
-        undergraduate - 40346
-        us - 40307
-        uci - 36904
-        data - 36550
-        2021 - 36408
-        events - 35106
-        informatics - 35047
-        news - 32568
-        students - 31262
-        software - 30242
-        2022 - 29945
-        2024 - 29452
-        faculty - 27234
-        markellekelly - 26855
-        community - 26220
-        information - 24310
-        2020 - 23708
-        alumni - 23617
-        october - 23601
-        view - 23266
-        10 - 22461
-        machine - 21812
-        spotlights - 21283
-        computing - 21272
-        future - 20966
-        2023 - 20924
-        programs - 19591
-        statistics - 19587
-        will - 19407
-        2018 - 19111
-        systems - 19087
-        projects - 18847
-        text - 18750
-        can - 18281
-        may - 18049
-        school - 17988
-        next - 17301
-        2019 - 17133
-        follow - 17075
-        11 - 16999
-        contrast - 16409
-        get - 16091
-        engineering - 16081
+        research - 91188
+        ics - 68925
+        student - 54834
+        science - 49716
+        computer - 45114
+        learning - 42188
+        graduate - 42012
+        undergraduate - 40680
+        us - 40616
+        2021 - 38551
+        uci - 37357
+        data - 37185
+        events - 35983
+        informatics - 35221
+        news - 32708
+        2022 - 31581
+        students - 31236
+        markellekelly - 30436
+        software - 30258
+        2024 - 30039
+        faculty - 27595
+        community - 26488
+        2020 - 24830
+        information - 24487
+        october - 23906
+        alumni - 23851
+        view - 23329
+        10 - 23211
+        machine - 22024
+        2023 - 21569
+        spotlights - 21381
+        future - 21070
+        computing - 21022
+        statistics - 20422
+        programs - 20002
+        systems - 19254
+        2018 - 19223
+        will - 19222
+        text - 18851
+        projects - 18829
+        school - 18291
+        11 - 17789
+        follow - 17214
+        2019 - 17198
+        contrast - 16508
+        engineering - 16102
+        2016 - 15898
+        12 - 15803
+        one - 15660
+        2017 - 15640
 
 4. How many subdomains did you find in the ics.uci.edu domain? Submit the list of subdomains ordered alphabetically and the 
 number of unique pages detected in each subdomain. The content of this list should be lines containing URL, number, for example:
@@ -123,6 +123,7 @@ http://vision.ics.uci.edu, 10 (not the actual number here)
 
 ICS subdomains:
         codeexchange.ics.uci.edu - 1
+        -db.ics.uci.edu - 37
         DataGuard.ics.uci.edu - 1
         DataProtector.ics.uci.edu - 1
         accessibility.ics.uci.edu - 6
@@ -134,13 +135,13 @@ ICS subdomains:
         awareness.ics.uci.edu - 1
         biaslab.ics.uci.edu - 1
         cbcl.ics.uci.edu - 56
-        cert.ics.uci.edu - 14
+        cert.ics.uci.edu - 28
         cgvw.ics.uci.edu - 1
-        checkmate.ics.uci.edu - 1
+        checkmate.ics.uci.edu - 3
         chenli.ics.uci.edu - 10
         cherry.ics.uci.edu - 1
         chime.ics.uci.edu - 1
-        cloudberry.ics.uci.edu - 45
+        cloudberry.ics.uci.edu - 47
         cml.ics.uci.edu - 167
         code.ics.uci.edu - 14
         codeexchange.ics.uci.edu - 1
@@ -157,12 +158,13 @@ ICS subdomains:
         cyberclub.ics.uci.edu - 52
         datalab.ics.uci.edu - 1
         dblp.ics.uci.edu - 2
-        dejavu.ics.uci.edu - 2
-        dgillen.ics.uci.edu - 31
+        dejavu.ics.uci.edu - 1
+        dgillen.ics.uci.edu - 32
         ds4all.ics.uci.edu - 3
         duke.ics.uci.edu - 1
-        duttgroup.ics.uci.edu - 115
-        dynamo.ics.uci.edu - 1
+        duttgroup.ics.uci.edu - 121
+        dynamo.ics.uci.edu - 35
+        earablegames.ics.uci.edu - 2
         edgelab.ics.uci.edu - 7
         eli.ics.uci.edu - 4
         emj-pc.ics.uci.edu - 1
@@ -175,10 +177,10 @@ ICS subdomains:
         frost.ics.uci.edu - 3
         futurehealth.ics.uci.edu - 149
         gbolcer.ics.uci.edu - 1
-        gitlab.ics.uci.edu - 986
+        gitlab.ics.uci.edu - 990
         grafana-infra-blue.ics.uci.edu - 1
-        grape.ics.uci.edu - 263
-        graphics.ics.uci.edu - 17
+        grape.ics.uci.edu - 270
+        graphics.ics.uci.edu - 20
         graphmod.ics.uci.edu - 16
         hack.ics.uci.edu - 2
         hai.ics.uci.edu - 6
@@ -192,7 +194,8 @@ ICS subdomains:
         i-sensorium.ics.uci.edu - 6
         iasl.ics.uci.edu - 22
         icde2023.ics.uci.edu - 43
-        ics.uci.edu - 4008
+        ics.ics.uci.edu - 772
+        ics.uci.edu - 20349
         ics45c-hub.ics.uci.edu - 2
         ics45c-staging-hub.ics.uci.edu - 2
         ics46-hub.ics.uci.edu - 2
@@ -200,13 +203,13 @@ ICS subdomains:
         ics53-hub.ics.uci.edu - 2
         ics53-staging-hub.ics.uci.edu - 2
         ieee.ics.uci.edu - 5
+        iki.ics.uci.edu - 74
         industryshowcase.ics.uci.edu - 24
-        informatics.ics.uci.edu - 2
+        informatics.ics.uci.edu - 3
         informatics.mt-live.ics.uci.edu - 1
-        informatics.uci.edu - 2
         insite.ics.uci.edu - 8
         ipubmed.ics.uci.edu - 1
-        isg.ics.uci.edu - 295
+        isg.ics.uci.edu - 338
         jgarcia.ics.uci.edu - 1
         jujube.ics.uci.edu - 2
         julia-hub.ics.uci.edu - 2
@@ -218,7 +221,7 @@ ICS subdomains:
         mapgrid.ics.uci.edu - 2
         mcs.ics.uci.edu - 15
         mdogucu.ics.uci.edu - 8
-        mds.ics.uci.edu - 30
+        mds.ics.uci.edu - 31
         metaviz.ics.uci.edu - 1
         mhcid.ics.uci.edu - 21
         mhcis.ics.uci.edu - 1
@@ -230,7 +233,7 @@ ICS subdomains:
         mswe.ics.uci.edu - 11
         mt-live.ics.uci.edu - 1
         nalini.ics.uci.edu - 7
-        ngs.ics.uci.edu - 1646
+        ngs.ics.uci.edu - 1512
         oai.ics.uci.edu - 6
         observium.ics.uci.edu - 1
         omni.ics.uci.edu - 1
@@ -248,11 +251,11 @@ ICS subdomains:
         sconce.ics.uci.edu - 1
         sdcl.ics.uci.edu - 204
         se.ics.uci.edu - 1
-        seal.ics.uci.edu - 42
+        seal.ics.uci.edu - 3
         seraja.ics.uci.edu - 2
         sherlock.ics.uci.edu - 8
         sli.ics.uci.edu - 451
-        sourcerer.ics.uci.edu - 1
+        sourcerer.ics.uci.edu - 2
         speedtest.ics.uci.edu - 1
         sprout.ics.uci.edu - 2
         staging-hub.ics.uci.edu - 1
@@ -263,7 +266,7 @@ ICS subdomains:
         studentcouncil.ics.uci.edu - 17
         students.ics.uci.edu - 1
         summeracademy.ics.uci.edu - 1
-        swiki.ics.uci.edu - 28
+        swiki.ics.uci.edu - 34
         tad.ics.uci.edu - 3
         tastier.ics.uci.edu - 1
         tippers.ics.uci.edu - 1
@@ -274,17 +277,5 @@ ICS subdomains:
         ugradforms.ics.uci.edu - 1
         unite.ics.uci.edu - 10
         vision.ics.uci.edu - 216
-        wearablegames.ics.uci.edu - 2
-        wics.ics.uci.edu - 761
-        wiki.ics.uci.edu - 79
-        www-db.ics.uci.edu - 37
-        www.cert.ics.uci.edu - 14
-        www.checkmate.ics.uci.edu - 2
-        www.graphics.ics.uci.edu - 3
-        www.ics.uci.edu - 16389
-        www.informatics.ics.uci.edu - 1
-        www.informatics.uci.edu - 1166
-        www.isg.ics.uci.edu - 1
-        www.mds.ics.uci.edu - 1
         xtune.ics.uci.edu - 6
         yarra.ics.uci.edu - 1

--- a/summary.py
+++ b/summary.py
@@ -141,13 +141,11 @@ def ics_subdomains(frontier_save_path: str) -> dict[str, int]:
         for url, completed in db.values(): 
             if completed: 
                 parsed_url = urlparse(url)
-                base_url = normalize(parsed_url._replace(query="", fragment="").geturl())
-                if "ics.uci.edu" in parsed_url.netloc:
-                    scheme = parsed_url.scheme
-                    subdomain = parsed_url.netloc
-                    url_key = subdomain
-                    # url_key = scheme + "://" + subdomain
-                    if subdomain in subdomains:
+                # base_url = normalize(parsed_url._replace(query="", fragment="").geturl())
+                subdomain = parsed_url.netloc
+                url_key = subdomain.removeprefix("http:").lstrip("\w.")
+                if "ics.uci.edu" in url_key and url_key != "informatics.uci.edu":
+                    if url_key in subdomains:
                         subdomains[url_key] += 1
                     else:
                         subdomains[url_key] = 1
@@ -163,7 +161,7 @@ if __name__ == "__main__":
     print(f"The longest page is {page} with {word_count} words.")
     
     # List longest pages
-    print("Longest Pages:")
+    print("The Top 50 Longest Pages:")
     for key, value in list_longest_pages('summary.shelve', 50):
         print(f"\t{key} - {value}")
 

--- a/summary.py
+++ b/summary.py
@@ -59,8 +59,7 @@ def update_token_frequency(summary_save_path: str, tokens: list[str]) -> None:
         token_frequencies = db.get("token_frequencies", Counter())
         
         # update
-        filtered_words = [token for token in tokens if token not in stop_words]
-        token_frequencies.update(filtered_words)
+        token_frequencies.update(tokens)
 
         # store back
         db["token_frequencies"] = token_frequencies
@@ -113,12 +112,20 @@ def list_longest_pages(summary_save_path: str, k: int) -> list[tuple]:
 
 def get_common_words(summary_save_path: str, k: int) -> dict[str, int]: 
     """
-    Gets 50 most common words across all the crawled pages
+    Gets k most common words across all the crawled pages
     """
     # Load existing save file, or create one if it does not exist.
     with shelve.open(summary_save_path) as db:
         token_frequencies = db.get("token_frequencies", Counter())
-        return token_frequencies.most_common(k)
+        
+        filtered_words = []
+        for word, count in token_frequencies.most_common():  # Iterate over all sorted words
+            if word not in stop_words:
+                filtered_words.append((word, count))
+            if len(filtered_words) >= k:  # Stop once we have 50 valid words
+                break
+        
+        return filtered_words
 
 def ics_subdomains(frontier_save_path: str) -> dict[str, int]:
     """


### PR DESCRIPTION
Made minor changes to methods create reporting statistics. Remove more common stop words from the top 50 most common words list. Removed leading 'ww.' and 'http:' from isc.uci.edu subdomains. Removed 'informatics.uci.edu' from list of ics.uci.edu subdomains.